### PR TITLE
Skip users without name

### DIFF
--- a/nuki/client.go
+++ b/nuki/client.go
@@ -227,7 +227,7 @@ func (c *Client) CreateUser(ctx context.Context, u *User) (*User, error) {
 		httptransport.BearerToken(c.beareToken),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get user %w", err)
+		return nil, fmt.Errorf("failed to create user %w", err)
 	}
 
 	return (*User)(userCreateRes.Payload), nil

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -143,9 +143,17 @@ func (s *syncGSuite) createNukiUsers(ctx context.Context, googleUsers []*admin.U
 		}
 
 		ll.Info("creating user")
+		name := u.Name.DisplayName
+		if name == "" {
+			name = u.Name.FullName
+		}
+		if name == "" {
+			log.Warn("skipping user without name")
+			continue
+		}
 		uu, err = s.nukiclient.CreateUser(ctx, &nuki.User{
 			Email: &u.PrimaryEmail,
-			Name:  ptr(u.Name.DisplayName),
+			Name:  ptr(name),
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
Nuki does not allow empty names for users, so we will fall back when
Displayname is empty to Fullname and if that is still empty we will skip
the user.
